### PR TITLE
feat: produce 3 separate datasets for experiment purposes

### DIFF
--- a/dataset/processed/courses_large.csv
+++ b/dataset/processed/courses_large.csv
@@ -1,0 +1,105 @@
+courses;weekly_hours;instructors;group
+Intro Asian American Studies;3.0;586;0
+Intro to Asian Am Pop Culture;3.0;527;0
+U.S. Race and Empire;3.0;134;0
+US Racial & Ethnic Politics;3.0;343;0
+Asian American Youth in Film;3.0;145;0
+The Politics of Fashion;3.0;536;0
+Constructing Race in America;3.0;219;0
+Asian American History;3.0;392;0
+Food and Asian Americans;3.0;438;0
+Asian Families in America;3.0;14;0
+Race and Cultural Diversity;3.0;475;0
+Immigration,Law,and Rights;3.0;186;0
+Adv Asian Am Undergrad Reading;3.0;89;0
+Asian American Education;3.0;523;1
+Intro Agric & Biological Engrg;3.0;167;1
+Undergraduate Open Seminar;3.0;592;1
+ABE Principles: Machine Syst;3.0;21;1
+ABE Principles: Soil & Water;3.0;135;1
+Transport Processes in ABE;3.0;236;1
+Off-Road Machine Design;3.0;448;1
+Independent Study;3.0;340;1
+Principles of Mobile Robotics;3.0;599;1
+Project Management;3.0;365;1
+Renewable Energy Systems;3.0;69;1
+Applied Statistical Methods I;3.0;493;1
+Statistical Methods;3.0;176;1
+Drainage and Water Management;3.0;39;2
+Engineering Off-Road Vehicles;3.0;45;2
+Indoor Air Quality Engineering;3.0;84;2
+Bioprocessing Biomass for Fuel;3.0;272;2
+Special Topics;3.0;377;2
+Graduate Research I;3.0;133;2
+Graduate Seminar;3.0;511;2
+Thesis Research;3.0;197;2
+Fundamentals of Accounting;3.0;76;2
+Accounting and Accountancy I;3.0;124;2
+Accounting and Accountancy II;3.0;253;2
+Prof Internship in Accountancy;3.0;52;2
+Atg Measurement & Disclosure;3.0;227;2
+Decision Making for Atg;3.0;131;3
+Accounting Institutions and Regulation;3.0;582;3
+Accounting Control Systems;3.0;177;3
+Principles of Taxation;3.0;79;3
+Principles of Public Policy;3.0;25;3
+Practical Problems in Atg;3.0;143;3
+Assurance and Attestation;3.0;477;3
+Advanced Financial Reporting;3.0;274;3
+Auditing Stds and Practice;3.0;338;3
+Advanced Income Tax Problems;3.0;319;3
+Senior Research;3.0;388;3
+Accounting Measurement,Reporting,and Control;1.0;515;3
+Accounting Analysis I;1.0;172;3
+Accounting Analysis II;1.0;441;4
+Auditing;1.0;227;4
+Federal Taxation;1.0;436;4
+Advanced Topics in Accounting;1.0;186;4
+Financial Reporting Standards;1.0;341;4
+Data Analytics for Management Accounting;1.0;237;4
+Auditing & Assurance Standards;1.0;295;4
+Financial Statement Analysis;1.0;584;4
+Financial Statement Fraud;3.0;331;4
+Corporate Income Taxation;3.0;453;4
+Tax Research;3.0;511;4
+Data Driven Decisions in Accounting;3.0;16;4
+Data Analytics Foundations for Accountancy;3.0;186;4
+Introduction to Accounting Research;3.0;70;5
+Special Research Problems;3.0;196;5
+Agr Cons and Resource Econ;3.0;56;5
+Microcomputer Applications;3.0;1;5
+Environmental Economics;3.0;94;5
+Agricultural Marketing;3.0;284;5
+Personal Financial Planning;3.0;414;5
+The World Food Economy;3.0;2;5
+Applied Statistical Methods;3.0;596;5
+Off-Campus Internship;3.0;407;5
+On-Campus Internship;3.0;145;5
+Food Law;3.0;418;5
+Issues&Careers in Applied Econ;3.0;84;5
+Finan Decision Indiv Sm Bus;3.0;480;6
+Tax Policy and Finan Planning;3.0;128;6
+Spreadsheet Models & Applic;3.0;293;6
+Honors Research or Thesis;3.0;141;6
+Seminar;3.0;107;6
+Environmental Law;3.0;354;6
+Environment and Development;3.0;437;6
+Commodity Price Analysis;3.0;291;6
+Commodity Futures and Options;3.0;216;6
+Farm Management;3.0;299;6
+Global Agribusiness Management;3.0;34;6
+Finan Serv & Invest Plan;3.0;578;6
+Intermediate Personal Fin Plan;1.0;219;6
+The Latin American Economies;1.0;219;7
+Intl Trade in Food and Agr;1.0;199;7
+Practicum;1.0;318;7
+Applied Economic Theory;1.0;497;7
+Risk and Info: Theory and App;1.0;298;7
+Time Series Econometrics for Price Analysis;1.0;380;7
+Impact Evaluation;1.0;328;7
+Applied Regression Models I;1.0;82;7
+Applied Regression Models II;1.0;345;7
+Career Development for PhDs;3.0;420;7
+Household Economics;3.0;31;7
+Seminars and Workshops;3.0;600;7
+Contemporary Issues in ACES;3.0;211;7

--- a/dataset/processed/courses_medium.csv
+++ b/dataset/processed/courses_medium.csv
@@ -1,0 +1,53 @@
+courses;weekly_hours;instructors;group
+Intro Asian American Studies;3.0;586;0
+Intro to Asian Am Pop Culture;3.0;527;0
+U.S. Race and Empire;3.0;134;0
+US Racial & Ethnic Politics;3.0;343;0
+Asian American Youth in Film;3.0;145;0
+The Politics of Fashion;3.0;536;0
+Constructing Race in America;3.0;219;0
+Asian American History;3.0;392;0
+Food and Asian Americans;3.0;438;0
+Asian Families in America;3.0;14;0
+Race and Cultural Diversity;3.0;475;0
+Immigration,Law,and Rights;3.0;186;0
+Adv Asian Am Undergrad Reading;3.0;89;0
+Asian American Education;3.0;523;1
+Intro Agric & Biological Engrg;3.0;167;1
+Undergraduate Open Seminar;3.0;592;1
+ABE Principles: Machine Syst;3.0;21;1
+ABE Principles: Soil & Water;3.0;135;1
+Transport Processes in ABE;3.0;236;1
+Off-Road Machine Design;3.0;448;1
+Independent Study;3.0;340;1
+Principles of Mobile Robotics;3.0;599;1
+Project Management;3.0;365;1
+Renewable Energy Systems;3.0;69;1
+Applied Statistical Methods I;3.0;493;1
+Statistical Methods;3.0;176;1
+Drainage and Water Management;3.0;39;2
+Engineering Off-Road Vehicles;3.0;45;2
+Indoor Air Quality Engineering;3.0;84;2
+Bioprocessing Biomass for Fuel;3.0;272;2
+Special Topics;3.0;377;2
+Graduate Research I;3.0;133;2
+Graduate Seminar;3.0;511;2
+Thesis Research;3.0;197;2
+Fundamentals of Accounting;3.0;76;2
+Accounting and Accountancy I;3.0;124;2
+Accounting and Accountancy II;3.0;253;2
+Prof Internship in Accountancy;3.0;52;2
+Atg Measurement & Disclosure;3.0;227;2
+Decision Making for Atg;3.0;131;3
+Accounting Institutions and Regulation;3.0;582;3
+Accounting Control Systems;3.0;177;3
+Principles of Taxation;3.0;79;3
+Principles of Public Policy;3.0;25;3
+Practical Problems in Atg;3.0;143;3
+Assurance and Attestation;3.0;477;3
+Advanced Financial Reporting;3.0;274;3
+Auditing Stds and Practice;3.0;338;3
+Advanced Income Tax Problems;3.0;319;3
+Senior Research;3.0;388;3
+Accounting Measurement,Reporting,and Control;1.0;515;3
+Accounting Analysis I;1.0;172;3

--- a/dataset/processed/courses_small.csv
+++ b/dataset/processed/courses_small.csv
@@ -1,0 +1,14 @@
+courses;weekly_hours;instructors;group
+Intro Asian American Studies;3.0;586;0
+Intro to Asian Am Pop Culture;3.0;527;0
+U.S. Race and Empire;3.0;134;0
+US Racial & Ethnic Politics;3.0;343;0
+Asian American Youth in Film;3.0;145;0
+The Politics of Fashion;3.0;536;0
+Constructing Race in America;3.0;219;0
+Asian American History;3.0;392;0
+Food and Asian Americans;3.0;438;0
+Asian Families in America;3.0;14;0
+Race and Cultural Diversity;3.0;475;0
+Immigration,Law,and Rights;3.0;186;0
+Adv Asian Am Undergrad Reading;3.0;89;0

--- a/src/scripts/dataset/courses_for_experiment.py
+++ b/src/scripts/dataset/courses_for_experiment.py
@@ -1,0 +1,58 @@
+import os
+from pathlib import Path
+import pandas as pd
+import csv
+
+# get project root, relative to this folder: if the folder changes, the path MUST be changed as well.
+PROJECT_ROOT = Path().resolve().parent.parent.parent
+
+# initialize the directory
+os.chdir(PROJECT_ROOT)
+coursesFilePath = Path('dataset/processed', 'courses.csv')
+
+# read courses.csv file
+courseFile = pd.read_csv(coursesFilePath, sep=";")
+courses = courseFile["courses"].to_list()
+
+# function to create new dataset
+def createNewDatasetOnGivenLength(dName, dLength):
+    datasetLength = 13 if dLength is None else dLength
+    datasetName = "small" if dName is None else dName
+
+    targetFilePath = Path("dataset/processed", "courses_"+datasetName+".csv")
+    targetFile = open(targetFilePath, 'w', newline="")
+    writer = csv.writer(targetFile, dialect="excel", delimiter=";")
+    writer.writerow(["courses", "weekly_hours", "instructors", "group"])
+    i = 0
+    while i != datasetLength:
+        writer.writerow([courseFile['courses'].to_list()[i:i+1], courseFile['weekly_hours'].to_list()[i:i+1],
+                        courseFile['instructors'].to_list()[i:i+1], courseFile['group'].to_list()[i:i+1]])
+        i += 1
+    targetFile.close()
+
+    cleanDataset(targetFilePath)
+
+def cleanDataset(targetFilePath):
+    with open(targetFilePath, "r+", encoding="utf-8") as csv_file:
+        content = csv_file.read()
+
+    with open(targetFilePath, "w+", encoding="utf-8") as csv_file:
+        newContent = content.replace('"', '').replace(
+            "[", "").replace("]", "").replace("\'", "").replace(", ", ",")
+        csv_file.write(newContent)
+
+# produce dataset
+# limit dataset on specific lengths for experiment purposes
+# small : [13 courses]
+# medium : [52 courses]
+# large : [104 courses]
+createNewDatasetOnGivenLength("small", 13)
+createNewDatasetOnGivenLength("medium", 52)
+createNewDatasetOnGivenLength("large", 104)
+
+
+
+
+
+
+


### PR DESCRIPTION
Issues:
The GA algorithm takes a long time to run on original dataset. Since we specified to do some experiments on multiple datasets in our midterm presentation, I decided to map the courses.csv file into 3 separate datasets for experiment purposes. The number of courses in each file follows the numbers specified in the presentation, but with small changes. 

Originally, we decided that each group will have 12 courses, so 12 for the small dataset (1 group), 48 for medium  (4 groups), and 96 for the large one  (8 groups). But after taking our current dataset into consideration, it's better to change the number to 13, because previously we decided that each group will have 13 courses. 

Here, courses_small.csv contains13 courses, courses_medium contains 52 courses, and courses_large contains 104 courses.

Changes:
- courses_for_experiment.py
- courses_small.csv
- courses_medium.csv
- courses_large.csv

Tests:
No tests had been done yet.